### PR TITLE
Reduce package size to 15%

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -3,3 +3,4 @@ examples
 .babelrc
 .gitignore
 webpack.config.js
+demo.gif


### PR DESCRIPTION
Since, 84.5% of space is being taken by this GIF in my node modules, removing it for good by adding it inside `.npmignore`
